### PR TITLE
Remove ACTIONS Section Heading from All BPs

### DIFF
--- a/docs/source/bp/asset_management.rst
+++ b/docs/source/bp/asset_management.rst
@@ -18,11 +18,6 @@ Goals
 #. Always know the physical location of hardware (|Maturity1| maturity)
 #. Conduct maintenance and protecting assets from loss, theft, and tampering (|Maturity1| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 .. _asset-management-maturity-one:
 
 |Maturity1| Maturity

--- a/docs/source/bp/backups.rst
+++ b/docs/source/bp/backups.rst
@@ -28,10 +28,6 @@ Goals
 #. Protect backups
 #. Test your recovery plan
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
 
 .. _backups-maturity-one:
 

--- a/docs/source/bp/cis_controls.rst
+++ b/docs/source/bp/cis_controls.rst
@@ -30,11 +30,6 @@ Goals
 
 #. Implement the appropriate IGs for your organization (|Maturity1| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 |Maturity1| Maturity
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 

--- a/docs/source/bp/encrypt_data_at_rest.rst
+++ b/docs/source/bp/encrypt_data_at_rest.rst
@@ -21,11 +21,6 @@ Goals
 #. Encrypt backups (|Maturity1| maturity)
 #. Encrypt removable devices, where practical, such as with USB devices (|Maturity2| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 .. _encrypt-data-at-rest-maturity-one:
 
 |Maturity1| Maturity

--- a/docs/source/bp/endpoint_protection.rst
+++ b/docs/source/bp/endpoint_protection.rst
@@ -34,11 +34,6 @@ Goals
 
 #. Get EDR services through the EI-ISAC or commercial vendors (|Maturity1| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 |Maturity1| Maturity
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 

--- a/docs/source/bp/exercising_plans.rst
+++ b/docs/source/bp/exercising_plans.rst
@@ -17,11 +17,6 @@ Goals
 #. Learn the types of exercises that make sense for your organization (|Maturity1| maturity)
 #. Participate in exercises or create your own (|Maturity1| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 |Maturity1| Maturity
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 

--- a/docs/source/bp/firewalls_ports.rst
+++ b/docs/source/bp/firewalls_ports.rst
@@ -20,11 +20,6 @@ Goals
 #. Enable firewall management on networks (|Maturity1| maturity)
 #. Enable firewall management on end-user devices (|Maturity1| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 .. _firewalls-ports-maturity-one:
 
 |Maturity1| Maturity

--- a/docs/source/bp/formal_assessment.rst
+++ b/docs/source/bp/formal_assessment.rst
@@ -26,11 +26,6 @@ Goals
 #. Use the results to improve your cybersecurity posture (|Maturity1| maturity)
 #. Implement a risk assessment program (|Maturity2| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 |Maturity1| Maturity
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 

--- a/docs/source/bp/incident_response.rst
+++ b/docs/source/bp/incident_response.rst
@@ -18,11 +18,6 @@ Goals
 #. Exercise your plans (|Maturity1| maturity)
 #. Conduct after-action reports following and incident (|Maturity2| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 .. _incident-response-maturity-one:
 
 |Maturity1| Maturity

--- a/docs/source/bp/join_ei_isac.rst
+++ b/docs/source/bp/join_ei_isac.rst
@@ -34,8 +34,8 @@ The EI-ISAC provides access to valuable services to fulfill many of the best pra
 * Discounts on training
 * Homeland Security Information Network (HSIN) portal access
 
-Goals
-**********************************************
+All Maturities
+&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 
 #. Understand what the EI-ISAC has to offer (|Maturity1| maturity)
 #. Join the EI-ISAC (|Maturity1| maturity)

--- a/docs/source/bp/managing_infrastructure.rst
+++ b/docs/source/bp/managing_infrastructure.rst
@@ -19,11 +19,6 @@ Goals
 #. Properly configure workstation permissions (|Maturity1| maturity)
 #. Leverage CIS Benchmarks for workstation and infrastructure configuration (|Maturity2| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 .. _managing-infrastructure-maturity-one:
 
 |Maturity1| Maturity

--- a/docs/source/bp/managing_remote_connections.rst
+++ b/docs/source/bp/managing_remote_connections.rst
@@ -31,11 +31,6 @@ Goals
 #. Understand VPN technology and its role in election environments (|Maturity1| maturity)
 #. Properly implement a VPN service with your environment (|Maturity1| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 .. _manage-remote-connections-maturity-one:
 
 |Maturity1| Maturity

--- a/docs/source/bp/managing_staff.rst
+++ b/docs/source/bp/managing_staff.rst
@@ -19,10 +19,8 @@ Goals
 #. Conduct background checks for new hires (|Maturity1| maturity)
 #. Use available cybersecurity training to improve your cybersecurity posture (|Maturity1| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions are the same for all maturity levels.
+All Maturities
+&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 
 #. Conduct at least a national agency check for any hires. Your state or county may have other background check options for you.
 #. Provide security awareness training for all staff.

--- a/docs/source/bp/managing_vendors.rst
+++ b/docs/source/bp/managing_vendors.rst
@@ -18,8 +18,8 @@ Goals
 
 #. Understand how to use procurements to achieve security goals (|Maturity1| maturity)
 
-Actions
-**********************************************
+All Maturities
+&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 
 For |bp_title|, the necessary actions are the same for all maturity levels.
 

--- a/docs/source/bp/mdbr.rst
+++ b/docs/source/bp/mdbr.rst
@@ -28,10 +28,8 @@ Goals
 
 #. Deploy MDBR for all internet-facing IT assets (|Maturity1| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions are the same for all maturity levels.
+All Maturities
+&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 
 #. If you're an EI-ISAC member, you can sign up for no-cost MDBR by registering at https://mdbr.cisecurity.org. You will be asked to provide the following information:
 

--- a/docs/source/bp/mdm_info.rst
+++ b/docs/source/bp/mdm_info.rst
@@ -27,11 +27,6 @@ Goals
 #. Recognize MDM and its potential impact on election administration (|Maturity1| maturity)
 #. Take action when you encounter misinformation (|Maturity1| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 |Maturity1| Maturity
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 

--- a/docs/source/bp/network_monitoring.rst
+++ b/docs/source/bp/network_monitoring.rst
@@ -21,11 +21,6 @@ Goals
 #. Understand what an :term:`IDS` is and why it's important (|Maturity1| maturity)
 #. Deploy an :term:`IDS` (|Maturity2| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 |Maturity1| Maturity
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 

--- a/docs/source/bp/patching_vuln_management.rst
+++ b/docs/source/bp/patching_vuln_management.rst
@@ -25,11 +25,6 @@ Goals
 #. Establish and execute on a policy for systems that need additional approvals prior to patching (|Maturity1| maturity)
 #. Establish a formal patch management plan leveraging automated tools and aligned with your asset management plan (|Maturity2| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 |Maturity1| Maturity
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 

--- a/docs/source/bp/physical_threats.rst
+++ b/docs/source/bp/physical_threats.rst
@@ -20,11 +20,6 @@ Goals
 #. Know what to do if you encounter an attempt to threaten or intimidate.
 #. Know where to get more support.
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions are the same for all maturity levels.
-
 #. Learn about doxing and take action to minimize risk through CISA's Insight on `Mitigating the Impacts of Doxing on Critical Infrastructure <https://www.cisa.gov/sites/default/files/publications/CISA%20Insight_Mitigating%20the%20Impacts%20of%20Doxing_508.pdf>`_.
 #. If you or anyone in your office receives an attempt to threaten or intimidate: 
 

--- a/docs/source/bp/public_asset_scanning.rst
+++ b/docs/source/bp/public_asset_scanning.rst
@@ -24,11 +24,6 @@ Goals
 #. Deploy web application scanning tools (|Maturity1| maturity)
 #. Use penetration testing to harden networks (|Maturity2| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 |Maturity1| Maturity
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 

--- a/docs/source/bp/removable_media.rst
+++ b/docs/source/bp/removable_media.rst
@@ -19,11 +19,6 @@ Goals
 #. Employ appropriate media sanitization (|Maturity1| maturity)
 #. Effectively use removable media in the election environment (|Maturity1| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity, as detailed below.
-
 |Maturity1| Maturity
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 

--- a/docs/source/bp/user_management.rst
+++ b/docs/source/bp/user_management.rst
@@ -24,11 +24,6 @@ Goals
 #. Employ least privilege, especially with administrative access, and revoke access appropriately (|Maturity1| maturity)
 #. Log user activity (|Maturity1| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 .. _user-management-maturity-one:
 
 |Maturity1| Maturity

--- a/docs/source/bp/websites.rst
+++ b/docs/source/bp/websites.rst
@@ -57,11 +57,6 @@ Goals
 #. Know about website defacements and how to prevent them  (|Maturity1| maturity)
 #. Enroll in the EI-ISAC's vulnerability disclosure program (|Maturity2| maturity)
 
-Actions
--------
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 |Maturity1| Maturity
 `````````````````````````
 

--- a/docs/source/bp/wireless_management.rst
+++ b/docs/source/bp/wireless_management.rst
@@ -20,11 +20,6 @@ Goals
 #. Deploy additional tools and measures to limit risk (|Maturity2| maturity)
 #. Deploy mutual MFA for wireless access (|Maturity3| maturity)
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions vary by maturity as detailed below.
-
 |Maturity1| Maturity
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 

--- a/docs/source/bp/working_with_IT.rst
+++ b/docs/source/bp/working_with_IT.rst
@@ -20,11 +20,6 @@ Goals
 #. [Goal 1]
 #. [Goal 2]
 
-Actions
-**********************************************
-
-For |bp_title|, the necessary actions [e.g., "are the same for all maturity levels", "vary by maturity as detailed below"]
-
 |Maturity1| Maturity
 &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&
 


### PR DESCRIPTION
Fixes #174

Tried to remove all Actions. I left the weird bookmarks there that existed for some of them. Perhaps we want to reszie the Maturity 1, 2 and 3 headings in the future. I couldn't render the HTML files locally to make sure they looked correct but would love to know how to do so in the future. 